### PR TITLE
Feat/allow extending base props

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,14 +4,10 @@
     "source.organizeImports": false,
     "source.fixAll.eslint": true
   },
-  "cSpell.words": [
-    "jsxs"
-  ],
+  "cSpell.words": ["jsxs", "JSXTE"],
   "json.schemas": [
     {
-      "fileMatch": [
-        "git-hook-tasks.config.json"
-      ],
+      "fileMatch": ["git-hook-tasks.config.json"],
       "url": "./node_modules/git-hook-tasks/dist/config/json-schema.json"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,49 @@ const App = () => {
 const html = await renderToHtmlAsync(<App label="Hello World!" />);
 ```
 
+## Extending the typings
+
+JSXTE should be able to parse any html attributes you put in, as well as custom web component tags, although you may see type errors if you use anything that is not defined in the library typings. If you wish to use them it is recommended you extend the typings to disable said errors.
+
+### Adding custom web component tags
+
+To add a typing for a custom web component simply add a declare block in one of your project `.ts` or `.tsx` files, like this one:
+
+```tsx
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "my-custom-web-component": {
+        /* here include the attributes your component can take */
+        "data-example-attribute"?: string;
+      };
+    }
+  }
+}
+
+// with it it's possible to use this without type errors:
+const MyComponent = () => (
+  <my-custom-web-component data-example-attribute="Hello"></my-custom-web-component>
+);
+```
+
+### Adding a global html attribute
+
+There is a dictionary of html attributes that are available for every default html tag, that dictionary can be extended like so:
+
+```tsx
+declare global {
+  namespace JSXTE {
+    interface BaseHTMLTagProps {
+      "new-attribute"?: string;
+    }
+  }
+}
+
+// with it it's possible to use this without type errors:
+const MyComponent = () => <div new-attribute="Hello"></div>;
+```
+
 ## Express JS View Engine
 
 You can also use `jsxte` with the Express View Engine. To do that, use the `expressExtend` to add the engine support, specify the views directory and then use the express response method `.render()`. The `.render()` method takes the component props as it's second argument.

--- a/__tests__/html-parser/render-to-html.test.tsx
+++ b/__tests__/html-parser/render-to-html.test.tsx
@@ -33,7 +33,7 @@ describe("renderToHTML", () => {
       return <button style={props.styles}>{props.label}</button>;
     };
 
-    const Template = ({ children }: JSX.ElementProps) => {
+    const Template = ({ children }: JSXTE.ElementProps) => {
       return (
         <html>
           <head>
@@ -113,7 +113,7 @@ describe("renderToHTML", () => {
       return <button style={props.styles}>{props.label}</button>;
     };
 
-    const Template = ({ children }: JSX.ElementProps) => {
+    const Template = ({ children }: JSXTE.ElementProps) => {
       return (
         <html>
           <head>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "version": "1.0.0",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "rm -rf ./dist && tsc",
+    "build": "rm -rf ./dist && tsc -p tsconfig.build.json",
     "test:lint": "eslint .",
     "test:tsc": "tsc --noEmit",
     "test:jest": "jest --coverage"

--- a/src/express/index.ts
+++ b/src/express/index.ts
@@ -16,7 +16,7 @@ const __express = async <P extends object>(
 
   try {
     // eslint-disable-next-line
-    const Component: JSX.AsyncComponent<P> = require(filePath).default;
+    const Component: JSXTE.AsyncComponent<P> = require(filePath).default;
     const html = await renderToHtmlAsync(createElement(Component, options));
     return callback(null, html);
   } catch (e) {

--- a/src/html-parser/base-html-parser/base-html-parser.ts
+++ b/src/html-parser/base-html-parser/base-html-parser.ts
@@ -1,4 +1,3 @@
-import type { JSXTagElem } from "../../jsx/jsx.types";
 import { mapAttributeName } from "../../string-template-parser/map-attribute-name";
 import type { HTMLElementStruct, RendererHTMLAttributes } from "../types";
 
@@ -9,7 +8,7 @@ export class HTMLElementResolver {
     this.attributeMap = attributeMap;
   }
 
-  resolveAttributes(element: JSXTagElem): RendererHTMLAttributes {
+  resolveAttributes(element: JSXTE.TagElement): RendererHTMLAttributes {
     const attributes: HTMLElementStruct["attributes"] = [];
 
     for (const [key, prop] of Object.entries(element.props)) {
@@ -21,7 +20,7 @@ export class HTMLElementResolver {
     return attributes;
   }
 
-  resolveChildren(element: JSXTagElem): JSX.Element[] {
+  resolveChildren(element: JSXTE.TagElement): JSX.Element[] {
     if (!element.props.children) return [];
 
     if (Array.isArray(element.props.children))
@@ -30,7 +29,7 @@ export class HTMLElementResolver {
     return [element.props.children as JSX.Element];
   }
 
-  resolveElement(element: JSXTagElem): HTMLElementStruct {
+  resolveElement(element: JSXTE.TagElement): HTMLElementStruct {
     const children = this.resolveChildren(element);
     const attributes = this.resolveAttributes(element);
 

--- a/src/html-parser/get-html-struct.ts
+++ b/src/html-parser/get-html-struct.ts
@@ -1,10 +1,9 @@
-import type { JSXTagElem } from "../jsx/jsx.types";
 import { HTMLElementResolver } from "./base-html-parser/base-html-parser";
 
 import type { HTMLElementStruct } from "./types";
 
 export const getHTMLStruct = (
-  element: JSXTagElem,
+  element: JSXTE.TagElement,
   attributeMap: Record<string, string>
 ): HTMLElementStruct => {
   if (typeof element.tag === "string") {

--- a/src/html-parser/jsx-elem-to-html.ts
+++ b/src/html-parser/jsx-elem-to-html.ts
@@ -1,9 +1,8 @@
-import type { JSXSyncElem } from "../jsx/jsx.types";
 import { pad } from "../utilities/pad";
 import { mapAttributesToHtmlTagString } from "./attribute-to-html-tag-string";
 import { getHTMLStruct } from "./get-html-struct";
 
-const isSyncElem = (e: JSX.Element): e is JSXSyncElem => true;
+const isSyncElem = (e: JSX.Element): e is JSXTE.SyncElement => true;
 
 export const jsxElemToHtmlSync = (
   element: JSX.Element,
@@ -19,7 +18,7 @@ export const jsxElemToHtmlSync = (
   }
 
   if (typeof element.tag !== "string") {
-    const subElem = element.tag(element.props) as any as JSXSyncElem;
+    const subElem = element.tag(element.props) as any as JSXTE.SyncElement;
 
     if (subElem instanceof Promise) {
       throw new Error(
@@ -75,7 +74,9 @@ export const jsxElemToHtmlAsync = async (
   }
 
   if (typeof element.tag !== "string") {
-    const subElem = (await element.tag(element.props)) as any as JSXSyncElem;
+    const subElem = (await element.tag(
+      element.props
+    )) as any as JSXTE.SyncElement;
 
     return await jsxElemToHtmlAsync(subElem, { indent, attributeMap });
   } else {

--- a/src/jsx/base-html-tag-props.ts
+++ b/src/jsx/base-html-tag-props.ts
@@ -2,103 +2,16 @@ import type { Rewrap } from "../html-parser/types";
 
 export type AttributeBool = true | false | "true" | "false";
 
-export type BaseHTMLTagProps = {
-  children?: JSX.ElementChildren;
-
-  accesskey?: string;
-  class?: string;
-  contenteditable?: AttributeBool;
-  dir?: "ltr" | "rtl" | "auto";
-  draggable?: AttributeBool | "auto";
-  hidden?: AttributeBool;
-  id?: string;
-  lang?: string;
-  onabort?: string;
-  onafterprint?: string;
-  onbeforeprint?: string;
-  onbeforeunload?: string;
-  onblur?: string;
-  oncanplay?: string;
-  oncanplaythrough?: string;
-  onchange?: string;
-  onclick?: string;
-  oncontextmenu?: string;
-  oncopy?: string;
-  oncuechange?: string;
-  oncut?: string;
-  ondblclick?: string;
-  ondrag?: string;
-  ondragend?: string;
-  ondragenter?: string;
-  ondragleave?: string;
-  ondragover?: string;
-  ondragstart?: string;
-  ondrop?: string;
-  ondurationchange?: string;
-  onemptied?: string;
-  onended?: string;
-  onerror?: string;
-  onfocus?: string;
-  onhashchange?: string;
-  oninput?: string;
-  oninvalid?: string;
-  onkeydown?: string;
-  onkeypress?: string;
-  onkeyup?: string;
-  onload?: string;
-  onloadeddata?: string;
-  onloadedmetadata?: string;
-  onloadstart?: string;
-  onmousedown?: string;
-  onmousemove?: string;
-  onmouseout?: string;
-  onmouseover?: string;
-  onmouseup?: string;
-  onmousewheel?: string;
-  onoffline?: string;
-  ononline?: string;
-  onpagehide?: string;
-  onpageshow?: string;
-  onpaste?: string;
-  onpause?: string;
-  onplay?: string;
-  onplaying?: string;
-  onpopstate?: string;
-  onprogress?: string;
-  onratechange?: string;
-  onreset?: string;
-  onresize?: string;
-  onscroll?: string;
-  onsearch?: string;
-  onseeked?: string;
-  onseeking?: string;
-  onselect?: string;
-  onstalled?: string;
-  onstorage?: string;
-  onsubmit?: string;
-  onsuspend?: string;
-  ontimeupdate?: string;
-  ontoggle?: string;
-  onunload?: string;
-  onvolumechange?: string;
-  onwaiting?: string;
-  onwheel?: string;
-  slot?: string;
-  spellcheck?: AttributeBool;
-  style?: string;
-  tabindex?: string | number;
-  title?: string;
-  translate?: "yes" | "no";
-};
-
 export type HTMLProps<T extends object = never> = Rewrap<
   ExtendBaseProps<
-    [T] extends [never] ? BaseHTMLTagProps : Partial<T> & BaseHTMLTagProps
+    [T] extends [never]
+      ? JSXTE.BaseHTMLTagProps
+      : Partial<T> & JSXTE.BaseHTMLTagProps
   >
 >;
 
 type ExtendBaseProps<P> = {
-  [K in keyof P]: TJSXExtends.AttributeAcceptedTypes extends {
+  [K in keyof P]: JSXTE.AttributeAcceptedTypes extends {
     [E in K]: infer T;
   }
     ? T | P[K]
@@ -106,7 +19,98 @@ type ExtendBaseProps<P> = {
 };
 
 declare global {
-  namespace TJSXExtends {
+  namespace JSXTE {
     interface AttributeAcceptedTypes {}
+
+    export interface BaseHTMLTagProps {
+      children?: JSX.ElementChildren;
+
+      accesskey?: string;
+      class?: string;
+      contenteditable?: AttributeBool;
+      dir?: "ltr" | "rtl" | "auto";
+      draggable?: AttributeBool | "auto";
+      hidden?: AttributeBool;
+      id?: string;
+      inert?: AttributeBool;
+      lang?: string;
+      onabort?: string;
+      onafterprint?: string;
+      onbeforeprint?: string;
+      onbeforeunload?: string;
+      onblur?: string;
+      oncanplay?: string;
+      oncanplaythrough?: string;
+      onchange?: string;
+      onclick?: string;
+      oncontextmenu?: string;
+      oncopy?: string;
+      oncuechange?: string;
+      oncut?: string;
+      ondblclick?: string;
+      ondrag?: string;
+      ondragend?: string;
+      ondragenter?: string;
+      ondragleave?: string;
+      ondragover?: string;
+      ondragstart?: string;
+      ondrop?: string;
+      ondurationchange?: string;
+      onemptied?: string;
+      onended?: string;
+      onerror?: string;
+      onfocus?: string;
+      onhashchange?: string;
+      oninput?: string;
+      oninvalid?: string;
+      onkeydown?: string;
+      onkeypress?: string;
+      onkeyup?: string;
+      onload?: string;
+      onloadeddata?: string;
+      onloadedmetadata?: string;
+      onloadstart?: string;
+      onmousedown?: string;
+      onmousemove?: string;
+      onmouseout?: string;
+      onmouseover?: string;
+      onmouseup?: string;
+      onmousewheel?: string;
+      onoffline?: string;
+      ononline?: string;
+      onpagehide?: string;
+      onpageshow?: string;
+      onpaste?: string;
+      onpause?: string;
+      onplay?: string;
+      onplaying?: string;
+      onpopstate?: string;
+      onprogress?: string;
+      onratechange?: string;
+      onreset?: string;
+      onresize?: string;
+      onscroll?: string;
+      onsearch?: string;
+      onseeked?: string;
+      onseeking?: string;
+      onselect?: string;
+      onstalled?: string;
+      onstorage?: string;
+      onsubmit?: string;
+      onsuspend?: string;
+      ontimeupdate?: string;
+      ontoggle?: string;
+      onunload?: string;
+      onvolumechange?: string;
+      onwaiting?: string;
+      onwheel?: string;
+      role?: string;
+      slot?: string;
+      spellcheck?: AttributeBool;
+      style?: string;
+      tabindex?: string | number;
+      title?: string;
+      translate?: "yes" | "no";
+    }
   }
 }

--- a/src/jsx/base-html-tag-props.ts
+++ b/src/jsx/base-html-tag-props.ts
@@ -22,7 +22,7 @@ declare global {
   namespace JSXTE {
     interface AttributeAcceptedTypes {}
 
-    export type TagElement = {
+    type TagElement = {
       type: "tag";
       tag:
         | string
@@ -31,12 +31,12 @@ declare global {
       props: ElementProps;
     };
 
-    export type TextNodeElement = {
+    type TextNodeElement = {
       type: "textNode";
       text: string;
     };
 
-    export type SyncElement = TagElement | TextNodeElement;
+    type SyncElement = TagElement | TextNodeElement;
 
     type ElementChildren =
       | JSX.Element
@@ -63,7 +63,7 @@ declare global {
       props: PropsWithChildren<P>
     ) => Promise<JSX.Element>;
 
-    export interface BaseHTMLTagProps {
+    interface BaseHTMLTagProps {
       children?: ElementChildren;
 
       accesskey?: string;

--- a/src/jsx/base-html-tag-props.ts
+++ b/src/jsx/base-html-tag-props.ts
@@ -22,8 +22,49 @@ declare global {
   namespace JSXTE {
     interface AttributeAcceptedTypes {}
 
+    export type TagElement = {
+      type: "tag";
+      tag:
+        | string
+        | ((props: ElementProps) => Element)
+        | ((props: ElementProps) => Promise<Element>);
+      props: ElementProps;
+    };
+
+    export type TextNodeElement = {
+      type: "textNode";
+      text: string;
+    };
+
+    export type SyncElement = TagElement | TextNodeElement;
+
+    type ElementChildren =
+      | JSX.Element
+      | string
+      | number
+      | Array<
+          JSX.Element | string | number | Array<JSX.Element | string | number>
+        >;
+
+    type ElementProps = {
+      children?: ElementChildren;
+      [k: string]: any;
+    };
+
+    type PropsWithChildren<P extends object> = P & {
+      children?: JSXTE.ElementChildren;
+    };
+
+    type Component<P extends object = {}> = (
+      props: PropsWithChildren<P>
+    ) => JSX.Element;
+
+    type AsyncComponent<P extends object = {}> = (
+      props: PropsWithChildren<P>
+    ) => Promise<JSX.Element>;
+
     export interface BaseHTMLTagProps {
-      children?: JSX.ElementChildren;
+      children?: ElementChildren;
 
       accesskey?: string;
       class?: string;

--- a/src/jsx/jsx-runtime.ts
+++ b/src/jsx/jsx-runtime.ts
@@ -1,6 +1,6 @@
 type CreateElementProps = {
   [k: string]: any;
-  children?: JSX.ElementChildren;
+  children?: JSXTE.ElementChildren;
 };
 
 export const createElement = (
@@ -50,7 +50,7 @@ export const createElement = (
     type: "tag",
     // @ts-expect-error
     tag,
-    props: props as JSX.ElementProps,
+    props: props as JSXTE.ElementProps,
   };
 };
 

--- a/src/jsx/jsx.types.ts
+++ b/src/jsx/jsx.types.ts
@@ -46,53 +46,12 @@ import type { TimeTagProps } from "./prop-types/time-jsx-props";
 import type { TrackTagProps } from "./prop-types/track-jsx-props";
 import type { VideoTagProps } from "./prop-types/video-jsx-props";
 
-export type JSXTagElem = {
-  type: "tag";
-  tag:
-    | string
-    | ((props: JSX.ElementProps) => Element)
-    | ((props: JSX.ElementProps) => Promise<Element>);
-  props: JSX.ElementProps;
-};
-
-export type JSXTextNodeElem = {
-  type: "textNode";
-  text: string;
-};
-
-export type JSXSyncElem = JSXTagElem | JSXTextNodeElem;
-
 declare global {
   namespace JSX {
-    type PropsWithChildren<P extends object> = P & {
-      children?: JSX.ElementChildren;
-    };
-
-    type Component<P extends object = {}> = (
-      props: PropsWithChildren<P>
-    ) => JSX.Element;
-
-    type AsyncComponent<P extends object = {}> = (
-      props: PropsWithChildren<P>
-    ) => Promise<JSX.Element>;
-
-    type ElementChildren =
-      | JSX.Element
-      | string
-      | number
-      | Array<
-          JSX.Element | string | number | Array<JSX.Element | string | number>
-        >;
-
-    type ElementProps = {
-      children?: ElementChildren;
-      [k: string]: any;
-    };
-
     type Element =
-      | JSXTagElem
-      | JSXTextNodeElem
-      | Promise<JSXTagElem | JSXTextNodeElem>;
+      | JSXTE.TagElement
+      | JSXTE.TextNodeElement
+      | Promise<JSXTE.TagElement | JSXTE.TextNodeElement>;
 
     type LibraryManagedAttributes<T, PropsWithChildren> = PropsWithChildren;
 

--- a/src/string-template-parser/jsx-elem-to-strings.ts
+++ b/src/string-template-parser/jsx-elem-to-strings.ts
@@ -1,8 +1,7 @@
-import type { JSXSyncElem } from "../jsx/jsx.types";
 import { mapAttributeName } from "./map-attribute-name";
 import { resolveElement } from "./resolve-element";
 
-const isSyncElem = (e: JSX.Element): e is JSXSyncElem => true;
+const isSyncElem = (e: JSX.Element): e is JSXTE.SyncElement => true;
 
 type TagFunctionArgs = [string[], any[]];
 
@@ -27,7 +26,7 @@ export const jsxElemToTagFuncArgsSync = (
   }
 
   if (typeof element.tag !== "string") {
-    const subElem = element.tag(element.props) as any as JSXSyncElem;
+    const subElem = element.tag(element.props) as any as JSXTE.SyncElement;
 
     if (subElem instanceof Promise) {
       throw new Error(

--- a/src/string-template-parser/resolve-element.ts
+++ b/src/string-template-parser/resolve-element.ts
@@ -1,5 +1,3 @@
-import type { JSXTagElem } from "../jsx/jsx.types";
-
 type GetArrayFromUnion<U> = Exclude<U, Exclude<U, Array<any>>>;
 type GetNonArraysFromUnion<U> = Exclude<U, Array<any>>;
 
@@ -17,7 +15,7 @@ function asArray<T>(v: T): AsArray<T> {
   }
 }
 
-export const resolveElement = (element: JSXTagElem) => {
+export const resolveElement = (element: JSXTE.TagElement) => {
   const { children, ...attributes } = element.props;
 
   return {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,14 +4,17 @@
     "module": "commonjs",
     "declaration": true,
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDirs": ["./src", "./__tests__"],
     "downlevelIteration": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "jsxFactory": "jsx",
+    "jsxFragmentFactory": "Fragment"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "__tests__/**/*"]
 }


### PR DESCRIPTION
From now on it should be possible to extend the BaseHTMLTagProps interface like so:
```tsx
declare global {
  namespace JSXTE {
    interface BaseHTMLTagProps {
      /* ... */
    }
  }
}